### PR TITLE
Fix menu item alignment by centering price with description

### DIFF
--- a/styles.css
+++ b/styles.css
@@ -253,7 +253,7 @@ body {
 .menu-item {
   display: flex;
   justify-content: space-between;
-  align-items: flex-start;
+  align-items: center;
   margin-bottom: 1.2rem;
 }
 


### PR DESCRIPTION
This change modifies the .menu-item CSS rule in styles.css to use align-items: center instead of flex-start, ensuring the drink names and prices align neatly on the same baseline in the menu grid on larger screens. Responsive behavior for small screens is left unchanged.